### PR TITLE
Add context for selected data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "d3": "^7.9.0",
         "lodash": "^4.17.21",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-select": "^5.8.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
@@ -850,6 +851,31 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
+      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+      "license": "MIT"
     },
     "node_modules/@fontsource/roboto": {
       "version": "5.1.0",
@@ -4187,6 +4213,12 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4585,6 +4617,27 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-select": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.3.tgz",
+      "integrity": "sha512-lVswnIq8/iTj1db7XCG74M/3fbGB6ZaluCzvwPGT5ZOjCdL/k0CLWhEK0vCBLuU5bHTEf6Gj8jtSvi+3v+tO1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
@@ -5155,6 +5208,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "d3": "^7.9.0",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-select": "^5.8.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,12 +8,19 @@ import {
   EMISSIONS_COLUMN_NAMES,
   LABEL_COLUMN_NAMES,
 } from './consts';
+import SelectedDataContext from './stores/SelectedDataContext';
 
 function App() {
   const [data, setData] = useState({
     allEmissions: null,
     equivEmissions: null,
     labels: null,
+  });
+
+  const [selectedData, setSelectedData] = useState({
+    naics: '',
+    depth: 0,
+    label: '',
   });
 
   // TODO: Context/state for selected data
@@ -80,26 +87,33 @@ function App() {
 
   return (
     <>
-      <div className="root-grid">
-        <div className="header">
-          <h1>Header ribbon</h1>
-        </div>
-        <div className="main-grid">
-          <PackedBubbleChart
-            data={data.equivEmissions}
-            labels={data.naicsLabels}
-          />
-        </div>
-        <div className="sidebar-grid">
-          <div className="sidebar-item">
-            <h2>Gas Emissions by Sector</h2>
+      <SelectedDataContext.Provider
+        value={{
+          selectedData,
+          setSelectedData,
+        }}
+      >
+        <div className="root-grid">
+          <div className="header">
+            <h1>Header ribbon</h1>
           </div>
-          <div className="sidebar-item">
-            <StackedBarChart data={data.equivEmissions} />
+          <div className="main-grid">
+            <PackedBubbleChart
+              data={data.equivEmissions}
+              labels={data.naicsLabels}
+            />
           </div>
-          <div className="sidebar-item">Sidebar item 2</div>
+          <div className="sidebar-grid">
+            <div className="sidebar-item">
+              <h2>Gas Emissions by Sector</h2>
+            </div>
+            <div className="sidebar-item">
+              <StackedBarChart data={data.equivEmissions} />
+            </div>
+            <div className="sidebar-item">Sidebar item 2</div>
+          </div>
         </div>
-      </div>
+      </SelectedDataContext.Provider>
     </>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ function App() {
     naics: '',
     depth: 0,
     label: '',
+    selectedEmissions: 'all',
   });
 
   // TODO: Context/state for selected data

--- a/src/components/PackedBubbleChart/PackedBubbleChart.jsx
+++ b/src/components/PackedBubbleChart/PackedBubbleChart.jsx
@@ -1,3 +1,4 @@
+import { Button } from '@mui/material';
 import useResizeObserver from '@react-hook/resize-observer';
 import * as d3 from 'd3';
 import { debounce, isEmpty } from 'lodash';
@@ -9,14 +10,15 @@ import {
   useRef,
   useState,
 } from 'react';
+import Select from 'react-select';
 import SelectedDataContext from '../../stores/SelectedDataContext';
+
 import './index.css';
 
 // TODO: add buttons for return to root/recenter at selected node in corner
 // TODO: If no children set opacity to 0 and display pie chart instead.
 
 function PackedBubbleChart({ data, labels }) {
-  // console.log(labels?.get('11'));
   const [selectedBubble, setSelectedBubble] = useState(null); // TODO: hoist into react context to allow for use in other components
   const { selectedData, setSelectedData } = useContext(SelectedDataContext);
   const bubbleDisplayed = (d) => d.depth <= selectedBubble.depth + 1;
@@ -68,15 +70,12 @@ function PackedBubbleChart({ data, labels }) {
   useEffect(() => {
     if (!selectedBubble || !selectedBubble.data) return;
     setSelectedData({
+      ...selectedData,
       naics: selectedBubble.data[0],
       depth: selectedBubble.depth,
       label: labels.get(selectedBubble.data[0]),
     });
   }, [selectedBubble]);
-
-  useEffect(() => {
-    console.log('root', hierarchyData);
-  }, [hierarchyData]);
 
   const [size, setSize] = useState({ width: 0, height: 0 });
   const graphRef = useRef(null); // When ref is created as null, React will map it to the JSX node it's assigned to on render.
@@ -211,12 +210,79 @@ function PackedBubbleChart({ data, labels }) {
       });
 
     svgRoot.call(zoom);
+    svgRoot.node().zoom = zoom;
     // .on('wheel.zoom', null);
     return zoom;
   }, [svgRoot]);
 
+  // For react-select
+  const selectedEmissionsOptions = [
+    {
+      label: 'Total emissions',
+      value: 'all',
+    },
+    {
+      label: 'Production emissions',
+      value: 'base',
+    },
+    {
+      label: 'Margins emissions',
+      value: 'margin',
+    },
+  ];
+
+  // https://github.com/JedWatson/react-select/issues/4201#issuecomment-874098561
+  const reactSelectStyle = {
+    menu: (base) => ({
+      ...base,
+      width: 'max-content',
+      minWidth: '100%',
+      zIndex: 5,
+    }),
+    menuPortal: (base) => ({
+      ...base,
+      zIndex: 9999,
+    }),
+  };
+
+  const handleReset = () => {
+    svgRoot.transition().duration(500).call(zoom.transform, d3.zoomIdentity);
+    setSelectedBubble(hierarchyData);
+  };
   return (
     <>
+      <Select
+        options={selectedEmissionsOptions}
+        value={selectedEmissionsOptions.label}
+        menuPortalTarget={document.body}
+        onChange={(e) =>
+          setSelectedData({ ...selectedData, selectedEmissions: e.value })
+        }
+        styles={reactSelectStyle}
+        defaultValue={selectedEmissionsOptions[0]}
+      />
+      <Button
+        variant="contained"
+        onClick={handleReset}
+        style={{
+          whiteSpace: 'nowrap',
+          minWidth: 'auto',
+          textTransform: 'none',
+        }}
+      >
+        Back to root
+      </Button>
+      <Button
+        variant="contained"
+        onClick={() => zoomAndCenterBubble(selectedBubble.parent)}
+        style={{
+          whiteSpace: 'nowrap',
+          minWidth: 'auto',
+          textTransform: 'none',
+        }}
+      >
+        Go to parent
+      </Button>
       <div ref={graphRef} className="main-container">
         <svg id="packed-bubble-chart" className="chart-container" />
       </div>

--- a/src/components/PackedBubbleChart/PackedBubbleChart.jsx
+++ b/src/components/PackedBubbleChart/PackedBubbleChart.jsx
@@ -1,7 +1,15 @@
 import useResizeObserver from '@react-hook/resize-observer';
 import * as d3 from 'd3';
 import { debounce, isEmpty } from 'lodash';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import SelectedDataContext from '../../stores/SelectedDataContext';
 import './index.css';
 
 // TODO: add buttons for return to root/recenter at selected node in corner
@@ -9,7 +17,8 @@ import './index.css';
 
 function PackedBubbleChart({ data, labels }) {
   // console.log(labels?.get('11'));
-  const [selectedBubble, setSelectedBubble] = useState(root); // TODO: hoist into react context to allow for use in other components
+  const [selectedBubble, setSelectedBubble] = useState(null); // TODO: hoist into react context to allow for use in other components
+  const { selectedData, setSelectedData } = useContext(SelectedDataContext);
   const bubbleDisplayed = (d) => d.depth <= selectedBubble.depth + 1;
   const labelDisplayed = (d) => d.depth === selectedBubble.depth + 1; // TODO: hide if font size < 1. move to tooltip.
   const color = d3
@@ -55,6 +64,19 @@ function PackedBubbleChart({ data, labels }) {
     setSelectedBubble(root);
     return root;
   }, [data]);
+
+  useEffect(() => {
+    if (!selectedBubble || !selectedBubble.data) return;
+    setSelectedData({
+      naics: selectedBubble.data[0],
+      depth: selectedBubble.depth,
+      label: labels.get(selectedBubble.data[0]),
+    });
+  }, [selectedBubble]);
+
+  useEffect(() => {
+    console.log('root', hierarchyData);
+  }, [hierarchyData]);
 
   const [size, setSize] = useState({ width: 0, height: 0 });
   const graphRef = useRef(null); // When ref is created as null, React will map it to the JSX node it's assigned to on render.

--- a/src/components/StackedBarChart/StackedBarChart.jsx
+++ b/src/components/StackedBarChart/StackedBarChart.jsx
@@ -160,6 +160,10 @@ const StackedBarChart = ({ data }) => {
         Hierarchy depth (0 = all industries, 1 = sector, 2 = subsector, etc.):{' '}
         {selectedData.depth}
       </div>
+      <div>
+        Data to display ('margin', 'base', 'all'):{' '}
+        {selectedData.selectedEmissions}
+      </div>
     </div>
   );
 };

--- a/src/components/StackedBarChart/StackedBarChart.jsx
+++ b/src/components/StackedBarChart/StackedBarChart.jsx
@@ -1,13 +1,16 @@
+import useResizeObserver from '@react-hook/resize-observer';
+import * as d3 from 'd3';
+import { debounce, isEmpty } from 'lodash';
 import React, {
-  useRef,
+  useCallback,
+  useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
-  useCallback,
 } from 'react';
-import * as d3 from 'd3';
-import useResizeObserver from '@react-hook/resize-observer';
-import { debounce, isEmpty } from 'lodash';
+import SelectedDataContext from '../../stores/SelectedDataContext.js';
+
 import './StackedBarChart.css';
 
 const StackedBarChart = ({ data }) => {
@@ -18,6 +21,8 @@ const StackedBarChart = ({ data }) => {
   const svgRef = useRef(null);
   const graphRef = useRef(null);
   const [size, setSize] = useState({ width: 0, height: 0 });
+
+  const { selectedData, _ } = useContext(SelectedDataContext);
 
   const handleResize = useCallback(
     debounce((entry) => {
@@ -149,6 +154,12 @@ const StackedBarChart = ({ data }) => {
   return (
     <div ref={graphRef} className="bar-chart-container">
       <svg ref={svgRef} style={{ padding: 0, margin: 0 }}></svg>
+      <div>Selected area: {selectedData.naics}</div>
+      <div>Area title: {selectedData.label}</div>
+      <div>
+        Hierarchy depth (0 = all industries, 1 = sector, 2 = subsector, etc.):{' '}
+        {selectedData.depth}
+      </div>
     </div>
   );
 };

--- a/src/stores/SelectedDataContext.js
+++ b/src/stores/SelectedDataContext.js
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+
+const SelectedDataContext = createContext();
+export default SelectedDataContext;


### PR DESCRIPTION
## Changes:
- Added `SelectedDataContext`. Context is object with following keys:
  ```
  {
    naics: '',
    depth: 0,
    label: '',
    selectedEmissions: 'all',
  }
  ```
  `naics`: 6-digit NAICS code. For upper hierarchies e.g. manufacturing sector 32XXXX, `naics` is zero-padded to 6 digits: `320000`.
  `depth`: encodes level of hierarchy of current view. Depth 0 means no bubble selected; 1 = sector level, 2 = subsector, and so on. Not all depths exist in a bubble; e.g. a sector might terminate at the industry group level (depth 3).
  `label`: Title of selected bubble.
  `selectedEmissions`: enum value `['all' | 'base' | 'margin']`.
- Added basic `Button`s for going up one hierarchy level and back to root. Added React `Select` dropdown for changing between selected emissions.

## Next steps:
- Properly format controls to make them float in the top right corner above the chart.
- Hook `selectedEmissions` selection into pie chart.

## Screenshots:
![image](https://github.com/user-attachments/assets/f718ab59-22fe-4ce5-804a-fcee05b6c966)

Closes #15 