### PR TITLE
Integrate pie chart

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import PackedBubbleChart from './components/PackedBubbleChart/PackedBubbleChart'
 import StackedBarChart from './components/StackedBarChart/StackedBarChart';
 import {
   DATAFILES,
+  DEFAULT_SELECTED_DATA,
   EMISSIONS_COLUMN_NAMES,
   LABEL_COLUMN_NAMES,
 } from './consts';
@@ -17,15 +18,8 @@ function App() {
     labels: null,
   });
 
-  const [selectedData, setSelectedData] = useState({
-    naics: '',
-    depth: 0,
-    label: '',
-    selectedEmissions: 'all',
-  });
+  const [selectedData, setSelectedData] = useState(DEFAULT_SELECTED_DATA);
 
-  // TODO: Context/state for selected data
-  // TODO: Compute derived data here e.g. emissions by sector/industry/gas
   useEffect(() => {
     const readCSV = async () => {
       const emissionsColMapper = (r) => {
@@ -67,7 +61,6 @@ function App() {
           labelsColMapper,
         );
         setData({
-          // TODO: hoist into react context to allow for use in other components
           allEmissions: allEmissionsData,
           equivEmissions: equivCO2EmissionsData,
           naicsLabels: new Map(naicsLabels),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -99,11 +99,8 @@ function App() {
             <h1>Header ribbon</h1>
           </div>
           <div className="main-grid">
-            <PackedBubbleChart
-              data={data.equivEmissions}
-              labels={data.naicsLabels}
-            />
-            {/* <PieChart ghgdata={data.allEmissions}/> The chart only shows for 'Soybean Farming using the code' */}
+            <PackedBubbleChart data={data} />
+            {/* <PieChart ghgdata={data.allEmissions} /> The chart only shows for 'Soybean Farming using the code' */}
           </div>
           <div className="sidebar-grid">
             <div className="sidebar-item">

--- a/src/components/PackedBubbleChart/PackedBubbleChart.jsx
+++ b/src/components/PackedBubbleChart/PackedBubbleChart.jsx
@@ -169,15 +169,15 @@ function PackedBubbleChart({ data }) {
     const scale = Math.min(size.width, size.height) / (b.r * 2);
     const circleHTML = e.currentTarget;
     const pieRadius = circleHTML.getAttribute('r') * scale;
-    setSelectedData({
-      ...selectedData,
+    setSelectedData((prevState) => ({
+      ...prevState,
       naics: b.data[0],
       depth: b.depth,
       label: labels.get(b.data[0]),
       terminalNode: !('children' in b),
       column: b.column,
       pieRadius: pieRadius,
-    });
+    }));
     zoomAndCenterBubble(b);
   }
 
@@ -260,21 +260,24 @@ function PackedBubbleChart({ data }) {
 
   function handleReset() {
     svgRoot.transition().duration(500).call(zoom.transform, d3.zoomIdentity);
-    setSelectedData(DEFAULT_SELECTED_DATA);
+    setSelectedData((prevState) => ({
+      ...DEFAULT_SELECTED_DATA,
+      selectedEmissions: prevState.selectedEmissions,
+    }));
     setSelectedBubble(hierarchyData);
   }
 
   function handleGoUp() {
     const b = selectedBubble.parent;
-    setSelectedData({
-      ...selectedData,
+    setSelectedData((prevState) => ({
+      ...prevState,
       naics: b.data[0],
       depth: b.depth,
       label: labels.get(b.data[0]),
       terminalNode: false,
       column: b.column,
       pieRadius: 0,
-    });
+    }));
 
     zoomAndCenterBubble(b);
   }
@@ -286,10 +289,13 @@ function PackedBubbleChart({ data }) {
         value={SELECTED_EMISSIONS_DROPDOWN_OPTIONS.label}
         menuPortalTarget={document.body}
         onChange={(e) =>
-          setSelectedData({ ...selectedData, selectedEmissions: e.value })
+          setSelectedData((prevState) => ({
+            ...prevState,
+            selectedEmissions: e.value,
+          }))
         }
-        styles={reactSelectStyle}
         defaultValue={SELECTED_EMISSIONS_DROPDOWN_OPTIONS[0]}
+        styles={reactSelectStyle}
       />
       <Button
         variant="contained"

--- a/src/components/PackedBubbleChart/PackedBubbleChart.jsx
+++ b/src/components/PackedBubbleChart/PackedBubbleChart.jsx
@@ -20,7 +20,7 @@ import {
 import PieChart from '../PieChart/PieChart';
 import './index.css';
 
-// TODO: fix react select value from resetting on bubble select change
+// TODO: update on resize without rerendering entire chart/resetting zoom/pan
 function PackedBubbleChart({ data }) {
   const { equivEmissions: totalData, naicsLabels: labels } = data;
 

--- a/src/components/PackedBubbleChart/index.css
+++ b/src/components/PackedBubbleChart/index.css
@@ -6,6 +6,7 @@
   border-color: ghostwhite;
   border-radius: 15px;
   overflow: hidden;
+  position: relative;
 }
 
 .chart-container {

--- a/src/components/PieChart/PieChart.jsx
+++ b/src/components/PieChart/PieChart.jsx
@@ -14,7 +14,7 @@ import SelectedDataContext from '../../stores/SelectedDataContext';
 // get x, y, r from selected Bubble. pass as prop.
 // get total vs base emission from select. pass as prop.
 // TODO: add title
-// TODO: move pie chart when scrolling and panning bubble chart. might have to move this into the original SVG.
+// TODO: add percentages
 // TODO: connect select box to change pie chart between total/margin/base
 
 const PieChart = ({ ghgdata }) => {
@@ -113,7 +113,7 @@ const PieChart = ({ ghgdata }) => {
       .transition()
       .delay(500) // Duration of the fade-in effect
       .duration(500)
-      .style('opacity', 100);
+      .style('opacity', selectedData.terminalNode * 100);
     // TODO: make this consistent for all GHG types
     const color = d3
       .scaleOrdinal()
@@ -162,8 +162,9 @@ const PieChart = ({ ghgdata }) => {
       .transition()
       .delay(500) // Duration of the fade-in effect
       .duration(500)
-      .style('pointer-events', 'all')
-      .style('opacity', 1);
+      .style('opacity', selectedData.terminalNode * 100);
+
+    sectors.transition().delay(1000).style('pointer-events', 'all');
 
     sectors
       .on('mouseover', function (event, d) {

--- a/src/components/PieChart/PieChart.jsx
+++ b/src/components/PieChart/PieChart.jsx
@@ -11,9 +11,11 @@ import React, {
 } from 'react';
 import SelectedDataContext from '../../stores/SelectedDataContext';
 
-// TODO: make this position absolute. stack on top of packed chart.
 // get x, y, r from selected Bubble. pass as prop.
 // get total vs base emission from select. pass as prop.
+// TODO: add title
+// TODO: move pie chart when scrolling and panning bubble chart. might have to move this into the original SVG.
+// TODO: connect select box to change pie chart between total/margin/base
 
 const PieChart = ({ ghgdata }) => {
   const { selectedData, setSelectedData } = useContext(SelectedDataContext);
@@ -92,21 +94,27 @@ const PieChart = ({ ghgdata }) => {
     const width = size.width;
     const height = size.height;
     const margin = 40;
-    const radius = Math.min(width, height) / 2 - margin;
+    const radius = selectedData.pieRadius;
 
     const svg = d3
       .select(svgRef.current)
       .attr('width', width + 200)
       .attr('height', height)
       .append('g')
-      .attr('transform', `translate(${radius + margin}, ${height / 2})`);
+      .attr('transform', `translate(${width / 2}, ${height / 2})`);
 
     const legendGroup = d3
       .select(svgRef.current)
       .append('g')
-      .attr('transform', `translate(${radius * 2 + margin * 2}, ${20})`);
+      .attr('transform', `translate(${width * 0.8}, ${height * 0.8})`)
+      .style('opacity', 0);
 
-    // TODO: make this universal for all GHG types
+    legendGroup
+      .transition()
+      .delay(500) // Duration of the fade-in effect
+      .duration(500)
+      .style('opacity', 100);
+    // TODO: make this consistent for all GHG types
     const color = d3
       .scaleOrdinal()
       .domain(aggregatedData.map((d) => d.ghg))
@@ -136,7 +144,8 @@ const PieChart = ({ ghgdata }) => {
       .style('border-radius', '4px')
       .style('pointer-events', 'none');
 
-    svg
+    // TODO: fix tooltip distance from cursor
+    const sectors = svg
       .selectAll('path')
       .data(data_ready)
       .enter()
@@ -144,9 +153,19 @@ const PieChart = ({ ghgdata }) => {
       .attr('d', arc)
       .attr('fill', (d) => color(d.data.ghg))
       .attr('stroke', 'white')
-      .style('stroke-width', '2px')
-      .style('opacity', 1)
+      .style('stroke-width', '0px')
+      .style('pointer-events', 'none')
+      .style('opacity', 0);
+
+    // Fade in each slice
+    sectors
+      .transition()
+      .delay(500) // Duration of the fade-in effect
+      .duration(500)
       .style('pointer-events', 'all')
+      .style('opacity', 1);
+
+    sectors
       .on('mouseover', function (event, d) {
         d3.select(this).transition().duration(200).style('opacity', 0.8);
         tooltip.transition().duration(200).style('opacity', 0.9);
@@ -154,13 +173,13 @@ const PieChart = ({ ghgdata }) => {
           .html(
             `<strong>Gas:</strong> ${d.data.ghg}<br><strong>Total:</strong> ${d.data.total.toLocaleString()}`,
           )
-          .style('left', `${event.pageX + 10}px`)
-          .style('top', `${event.pageY - 28}px`);
+          .style('left', `${event.pageX}px`)
+          .style('top', `${event.pageY}px`);
       })
       .on('mousemove', function (event) {
         tooltip
-          .style('left', `${event.pageX + 10}px`)
-          .style('top', `${event.pageY - 28}px`);
+          .style('left', `${event.pageX}px`)
+          .style('top', `${event.pageY}px`);
       })
       .on('mouseout', function () {
         d3.select(this).transition().duration(200).style('opacity', 1);

--- a/src/components/PieChart/PieChart.jsx
+++ b/src/components/PieChart/PieChart.jsx
@@ -39,25 +39,17 @@ const PieChart = ({ ghgdata }) => {
 
   // Aggregate and filter data to include only gases with slice angle >= 1 degree
   const aggregatedData = useMemo(() => {
-    console.log('repie');
     if (isEmpty(ghgdata) || !selectedData.terminalNode) return [];
-
-    const depthToColumnMap = [
-      'sector',
-      'subsector',
-      'indGroup',
-      'industry',
-      'naics',
-    ];
 
     const filter =
       selectedData.depth > 0
-        ? (d) =>
-            d[depthToColumnMap[selectedData.depth - 1]] === selectedData.naics
+        ? (d) => d[selectedData.column] === selectedData.naics
         : () => false;
     console.log(
       'filtering on column ',
-      depthToColumnMap[selectedData.depth - 1],
+      selectedData.column,
+      ' == ',
+      selectedData.naics,
     );
 
     // Filter data
@@ -88,6 +80,7 @@ const PieChart = ({ ghgdata }) => {
       finalData.push({ ghg: 'Other gases', total: otherTotal });
     }
 
+    console.log(filteredData);
     return finalData;
   }, [ghgdata, selectedData]);
 
@@ -113,6 +106,7 @@ const PieChart = ({ ghgdata }) => {
       .append('g')
       .attr('transform', `translate(${radius * 2 + margin * 2}, ${20})`);
 
+    // TODO: make this universal for all GHG types
     const color = d3
       .scaleOrdinal()
       .domain(aggregatedData.map((d) => d.ghg))

--- a/src/components/PieChart/PieChart.jsx
+++ b/src/components/PieChart/PieChart.jsx
@@ -16,6 +16,7 @@ import SelectedDataContext from '../../stores/SelectedDataContext';
 // TODO: add title
 // TODO: add percentages
 // TODO: connect select box to change pie chart between total/margin/base
+// TODO: update on resize without rerendering entire chart/resetting zoom/pan
 
 const PieChart = ({ ghgdata }) => {
   const { selectedData, setSelectedData } = useContext(SelectedDataContext);

--- a/src/components/PieChart/PieChart.jsx
+++ b/src/components/PieChart/PieChart.jsx
@@ -17,6 +17,7 @@ import SelectedDataContext from '../../stores/SelectedDataContext';
 // TODO: add percentages
 // TODO: connect select box to change pie chart between total/margin/base
 // TODO: update on resize without rerendering entire chart/resetting zoom/pan
+// TODO: change pie chart from absolute to equivalent CO2 GWP units
 
 const PieChart = ({ ghgdata }) => {
   const { selectedData, setSelectedData } = useContext(SelectedDataContext);
@@ -107,7 +108,7 @@ const PieChart = ({ ghgdata }) => {
     const legendGroup = d3
       .select(svgRef.current)
       .append('g')
-      .attr('transform', `translate(${width * 0.8}, ${height * 0.8})`)
+      .attr('transform', `translate(${width * 0.75}, ${height * 0.825})`)
       .style('opacity', 0);
 
     legendGroup

--- a/src/consts.js
+++ b/src/consts.js
@@ -20,3 +20,29 @@ export const LABEL_COLUMN_NAMES = {
   NAICS: '2017 NAICS US Code',
   TITLE: '2017 NAICS US Title',
 };
+
+// For react-select
+export const SELECTED_EMISSIONS_DROPDOWN_OPTIONS = [
+  {
+    label: 'Total emissions',
+    value: 'total',
+  },
+  {
+    label: 'Production emissions',
+    value: 'base',
+  },
+  {
+    label: 'Margins emissions',
+    value: 'margin',
+  },
+];
+
+export const DEFAULT_SELECTED_DATA = {
+  naics: '',
+  depth: 0,
+  label: '',
+  terminalNode: false,
+  column: 'sector',
+  pieRadius: 0,
+  selectedEmissions: 'total',
+};


### PR DESCRIPTION
## Changes
- Update context with new field `column`. This is the source of truth for the level of the hierarchy the bubble is currently in.
- Pie chart data updates based on selected bubble.
- Pie chart is overlaid on top of selected bubble with matching radius when the bubble has no child bubbles, hidden otherwise.
- **Disabled universal zoom/pan**. User can now only navigate by clicking in/out of bubbles and on the reset/go to parent buttons.
- Fixed selectedData state resetting on bubble select change.

## Issues
- Window resize will reset the zoom/pan of the graph.
- On small window sizes the bubble chart will not be scaled to fit the box size.

## Screenshot
![image](https://github.com/user-attachments/assets/89eb8382-f832-47bd-bc73-c91b22ebeb1d)

Closes #16 
